### PR TITLE
[#Issue 1] Alteração dos scripts do  README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,28 @@
 ## Como rodar o projeto:
 - Instalar dependências do projeto
 ```bash
-  yarn ou npm install
+  yarn
 ``` 
+ou
+```bash
+  npm install
+```
 - Comando de desenvolvimento:
 ```bash
-  yarn dev ou npm run dev
+  yarn dev
 ```
-
+ou 
+```bash
+  npm run dev
+```
 - Comnado de execução:
 ```bash
-  yarn start ou npm start
+  yarn start
 ```
-
+ou 
+```bash
+  npm start
+```
 ### obs:
 - Projeto inicializado com yarn, mas fica a critério de quem for usar, escolher se continuará com o **yarn**, ou excluirá o _yarn.lock_ e usará os comandos do **npm**. 
 


### PR DESCRIPTION
### O que
- [x] Troca ordem dos scripts para rodar o projeto

### Porque
- A fim de facilitar para que quem venha a clonar o projeto não confundir se precisa rodar o comando `yarn ou npm install` como se fosse uma coisa só.  